### PR TITLE
Add binary that copies stdin to stdout, stripping escape sequences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ keywords = ["ansi", "escape", "terminal"]
 
 [dependencies]
 vte = "0.3.2"
+
+[dev-dependencies]
+executable-path = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -55,4 +55,3 @@ Licensed under either of
   * MIT license ([`LICENSE-MIT`](./LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,13 @@
+use std::{io, process};
+use strip_ansi_escapes::Writer;
+
+extern crate strip_ansi_escapes;
+
+fn main() {
+    let mut writer = Writer::new(io::stdout());
+
+    if let Err(error) = std::io::copy(&mut io::stdin(), &mut writer) {
+        eprintln!("I/O error copying stdin to stdout: {}", error);
+        process::exit(1);
+    }
+}

--- a/tests/binary.rs
+++ b/tests/binary.rs
@@ -1,0 +1,52 @@
+use executable_path::executable_path;
+use std::{
+    io::Write,
+    process::{Command, Stdio},
+    str,
+};
+
+extern crate executable_path;
+
+#[test]
+fn pass_normal_text_through() {
+    let mut child = Command::new(executable_path("strip-ansi-escapes"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all("hello".as_bytes())
+        .unwrap();
+
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success());
+
+    assert_eq!(str::from_utf8(&output.stdout).unwrap(), "hello");
+}
+
+#[test]
+fn strip_escape_sequences() {
+    let mut child = Command::new(executable_path("strip-ansi-escapes"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all("foo\x1B7bar".as_bytes())
+        .unwrap();
+
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success());
+
+    assert_eq!(str::from_utf8(&output.stdout).unwrap(), "foobar");
+}


### PR DESCRIPTION
I wanted this for testing, and thought others might also find it useful.

It adds a binary that copies standard input to standard output, stripping escape sequences.