### PR TITLE
bump vte dependency to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ readme = "README.md"
 keywords = ["ansi", "escape", "terminal"]
 
 [dependencies]
-vte = "0.3.2"
+vte = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,13 +149,6 @@ where
             self.err = writeln!(self.writer).err();
         }
     }
-    // Since we're not actually implementing a terminal, we just ignore everything else.
-    fn hook(&mut self, _params: &[i64], _intermediates: &[u8], _ignore: bool) {}
-    fn put(&mut self, _byte: u8) {}
-    fn unhook(&mut self) {}
-    fn osc_dispatch(&mut self, _params: &[&[u8]]) {}
-    fn csi_dispatch(&mut self, _params: &[i64], _intermediates: &[u8], _ignore: bool, _: char) {}
-    fn esc_dispatch(&mut self, _params: &[i64], _intermediates: &[u8], _ignore: bool, _byte: u8) {}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Numerous parsing bugs have been fixed and all Perform methods are now optional, so only print and execute need to be implemented.

[Full changelog](https://github.com/alacritty/vte/compare/v0.3.2...v0.10.1#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed)