### PR TITLE
remove the indirect dependency on arrayvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 keywords = ["ansi", "escape", "terminal"]
 
 [dependencies]
-vte = "0.10"
+vte = { version = "0.10", default-features = false }
 
 [dev-dependencies]
 doc-comment = "0.3"


### PR DESCRIPTION
I ran `cargo test` after turning off `default-features` and everything continued to work as expected. 
This will result in projects depending on this crate no longer pulling in an old `arrayvec`.

