### PR TITLE
Bump `0.2.0` to reflect semver-incompatible change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strip-ansi-escapes"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 license = "Apache-2.0/MIT"
 description = "Strip ANSI escape sequences from byte streams."


### PR DESCRIPTION
As mentioned in #17, #11 among other things changed the public API in a way that causes failures to build.

Thus those changes should be released under the `0.2.0` version to not break existing or new projects that don't lock the version to `0.1.1`.

To close #17, and stop churn for the ecosystem `0.1.2` would need to be yanked as well.
