### PR TITLE
bump vte to version 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 keywords = ["ansi", "escape", "terminal"]
 
 [dependencies]
-vte = { version = "0.11", default-features = false }
+vte = { version = "0.13", default-features = false }
 
 [dev-dependencies]
 doc-comment = "0.3"


### PR DESCRIPTION
There have been a few new minor vte versions released. This patch just bumps to the lastest one. There were no compile issues and the tests all pass so this seems to be an upgrade that does not really impact the usage of strip-ansi-escapes.

I'm doing this because I vendor deps and keeping everything current is the best way to avoid a proliferation of different versions of the same library.

The change is trivial enough that I figured opening an issue first would be overkill.