### PR TITLE
Upgrade `vte` to version 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 keywords = ["ansi", "escape", "terminal"]
 
 [dependencies]
-vte = { version = "0.13", default-features = false }
+vte = { version = "0.14", default-features = false }
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,9 +129,7 @@ where
     W: Write,
 {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        for b in buf.iter() {
-            self.parser.advance(&mut self.performer, *b)
-        }
+        self.parser.advance(&mut self.performer, buf);
         match self.performer.err.take() {
             Some(e) => Err(e),
             None => Ok(buf.len()),


### PR DESCRIPTION
@luser Thank you very much for merging #19.

`vte` is now at version 0.14. Do you think it would be possible to upgrade the version that `strip-ansi-escapes` uses?

If so, do you think it would be possible to publish a new release shortly thereafter?